### PR TITLE
Hide the webview when loading

### DIFF
--- a/app/src/main/java/cs/hku/hk/moodlehelper/activities/MoodleContent.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/activities/MoodleContent.java
@@ -148,6 +148,7 @@ public class MoodleContent extends AppCompatActivity
             {
                 super.onPageStarted(view, url, favicon);
                 bar.setVisibility(View.VISIBLE);
+                webView.setVisibility(View.GONE);
             }
 
             @Override
@@ -230,7 +231,7 @@ public class MoodleContent extends AppCompatActivity
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event)
     {
-        if(keyCode==KeyEvent.KEYCODE_BACK && webView.canGoBack())
+        if(keyCode==KeyEvent.KEYCODE_BACK && webView.canGoBack() && ! webView.getUrl().equals(courseURL.toString()))
         {
             webView.goBack();
             return true;


### PR DESCRIPTION
1. Hide the webview when it is loading & logging in
1. Avoid backing to the login view