### PR TITLE
Course titles and multi languages

### DIFF
--- a/app/src/main/java/cs/hku/hk/moodlehelper/activities/SettingsActivity.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/activities/SettingsActivity.java
@@ -130,7 +130,7 @@ public class SettingsActivity extends AppCompatActivity implements CourseCardBas
         }
         if(!storedPIN.equals(""))
         {
-            mUID.setText(R.string.initial_pin_unchanged);
+            mPIN.setHint(R.string.initial_pin_unchanged);
         }
     }
 

--- a/app/src/main/java/cs/hku/hk/moodlehelper/activities/SettingsActivity.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/activities/SettingsActivity.java
@@ -70,14 +70,22 @@ public class SettingsActivity extends AppCompatActivity implements CourseCardBas
                             {
                                 final EditText courseName = addCourseView.findViewById(R.id.edit_course_name);
                                 final EditText courseUrl = addCourseView.findViewById(R.id.edit_course_url);
+                                final EditText courseTitle = addCourseView.findViewById(R.id.edit_course_title);
 
                                 String courseNameStr = courseName.getText().toString();
                                 String courseUrlStr = courseUrl.getText().toString();
+                                String courseTitleStr = courseTitle.getText().toString();
 
                                 SharedPreferences sharedPreferences = getSharedPreferences("courses", MODE_PRIVATE);
                                 SharedPreferences.Editor editor = sharedPreferences.edit();
                                 editor.putString(courseNameStr,courseUrlStr);
                                 editor.apply();
+
+                                sharedPreferences = getSharedPreferences("names", MODE_PRIVATE);
+                                editor = sharedPreferences.edit();
+                                editor.putString(courseNameStr,courseTitleStr);
+                                editor.apply();
+
                                 mAdapter.refreshCourseList();
                                 mAdapter.notifyDataSetChanged();
                             }
@@ -114,10 +122,15 @@ public class SettingsActivity extends AppCompatActivity implements CourseCardBas
 
         SharedPreferences sp = getSharedPreferences("user", MODE_PRIVATE);
         String storedUID = sp.getString("portalID", "");
+        String storedPIN = sp.getString("portalPIN", "");
 
         if(!storedUID.equals(""))
         {
             mUID.setText(storedUID);
+        }
+        if(!storedPIN.equals(""))
+        {
+            mUID.setText(R.string.initial_pin_unchanged);
         }
     }
 
@@ -153,12 +166,17 @@ public class SettingsActivity extends AppCompatActivity implements CourseCardBas
 
         final EditText courseName = addCourseView.findViewById(R.id.edit_course_name);
         final EditText courseUrl = addCourseView.findViewById(R.id.edit_course_url);
-        final SharedPreferences sharedPreferences = getSharedPreferences("courses", MODE_PRIVATE);
-        final String urlStr = sharedPreferences.getString(name,getString(R.string.example_course_url));
+        final EditText courseTitle = addCourseView.findViewById(R.id.edit_course_title);
+        final SharedPreferences courseUrls = getSharedPreferences("courses", MODE_PRIVATE);
+        final SharedPreferences courseTitles = getSharedPreferences("names", MODE_PRIVATE);
+        //TODO: use the courseTitles in UI
+        final String urlStr = courseUrls.getString(name,getString(R.string.example_course_url));
+        final String titleStr = courseTitles.getString(name, getString(R.string.example_course_title));
 
         courseName.setText(name);
         courseName.setEnabled(false);
         courseUrl.setText(urlStr);
+        courseTitle.setText(titleStr);
 
         builder.setPositiveButton(R.string.confirm,
                 new DialogInterface.OnClickListener()
@@ -168,10 +186,16 @@ public class SettingsActivity extends AppCompatActivity implements CourseCardBas
                     {
 
                         String courseUrlStr = courseUrl.getText().toString();
+                        String courseTitleStr = courseTitle.getText().toString();
 
-                        SharedPreferences.Editor editor = sharedPreferences.edit();
+                        SharedPreferences.Editor editor = courseUrls.edit();
                         editor.putString(name,courseUrlStr);
                         editor.apply();
+
+                        editor = courseTitles.edit();
+                        editor.putString(name, courseTitleStr);
+                        editor.apply();
+
                         mAdapter.refreshCourseList();
                         mAdapter.notifyDataSetChanged();
                     }
@@ -189,9 +213,14 @@ public class SettingsActivity extends AppCompatActivity implements CourseCardBas
                     @Override
                     public void onClick(DialogInterface dialog, int which)
                     {
-                        SharedPreferences.Editor editor = sharedPreferences.edit();
+                        SharedPreferences.Editor editor = courseUrls.edit();
                         editor.remove(name);
                         editor.apply();
+
+                        editor = courseTitles.edit();
+                        editor.remove(name);
+                        editor.apply();
+
                         mAdapter.refreshCourseList();
                         mAdapter.notifyDataSetChanged();
                     }

--- a/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardBaseAdapter.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardBaseAdapter.java
@@ -171,7 +171,7 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
         Course(String courseName, String courseTitle, String urlStr)
         {
             this.courseName = courseName;
-            this.courseTitle = courseTitle.equals("")?rootView.getContext().getString(R.string.empty_course_title):courseTitle;
+            this.courseTitle = courseTitle.equals("") || courseTitle.matches("[\t ]*")?rootView.getContext().getString(R.string.empty_course_title):courseTitle;
             try
             {
                 this.courseURL = new URL(urlStr);

--- a/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardBaseAdapter.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardBaseAdapter.java
@@ -171,7 +171,7 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
         Course(String courseName, String courseTitle, String urlStr)
         {
             this.courseName = courseName;
-            this.courseTitle = courseTitle;
+            this.courseTitle = courseTitle.equals("")?rootView.getContext().getString(R.string.empty_course_title):courseTitle;
             try
             {
                 this.courseURL = new URL(urlStr);
@@ -209,7 +209,7 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
                     {
                         continue;
                     }
-                    courses.add(new Course(entry.getKey(), titles.getString(entry.getKey(),"DEFAULT COURSE TITLE"),courseUrlStr));
+                    courses.add(new Course(entry.getKey(), titles.getString(entry.getKey(),""),courseUrlStr));
                 }
             }
             else

--- a/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardBaseAdapter.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardBaseAdapter.java
@@ -59,8 +59,9 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
     {
         String tempURLStr = courses.get(position).courseURL.toString();
         int idStart = tempURLStr.indexOf("id=");
+        String tempCourseName = courses.get(position).courseName + ": " + courses.get(position).courseTitle;
 
-        holder.courseName.setText(courses.get(position).courseName);
+        holder.courseName.setText(tempCourseName);
         holder.courseId.setText(tempURLStr.substring(idStart));
     }
 
@@ -161,14 +162,16 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
     /**
      * Abstraction for each course. Converting course url string into URL
      */
-    protected class Course
+    class Course
     {
         String courseName;
         URL courseURL;
+        String courseTitle;
 
-        Course(String courseName, String urlStr)
+        Course(String courseName, String courseTitle, String urlStr)
         {
             this.courseName = courseName;
+            this.courseTitle = courseTitle;
             try
             {
                 this.courseURL = new URL(urlStr);
@@ -187,6 +190,7 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
     public void refreshCourseList()
     {
         SharedPreferences sp = rootView.getContext().getSharedPreferences("courses", Context.MODE_PRIVATE);
+        SharedPreferences titles = rootView.getContext().getSharedPreferences("names", Context.MODE_PRIVATE);
         courses.clear();
 
         if(sp != null)
@@ -205,7 +209,7 @@ public class CourseCardBaseAdapter extends RecyclerView.Adapter<CourseCardBaseAd
                     {
                         continue;
                     }
-                    courses.add(new Course(entry.getKey(),courseUrlStr));
+                    courses.add(new Course(entry.getKey(), titles.getString(entry.getKey(),"DEFAULT COURSE TITLE"),courseUrlStr));
                 }
             }
             else

--- a/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardButtonAdapter.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardButtonAdapter.java
@@ -98,7 +98,7 @@ public class CourseCardButtonAdapter extends CourseCardBaseAdapter
                     {
                         continue;
                     }
-                    courses.add(new Course(entry.getKey(), titles.getString(entry.getKey(),"DEFAULT COURSE TITLE"),courseUrlStr));
+                    courses.add(new Course(entry.getKey(), titles.getString(entry.getKey(),""),courseUrlStr));
                 }
             }
             else

--- a/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardButtonAdapter.java
+++ b/app/src/main/java/cs/hku/hk/moodlehelper/supports/CourseCardButtonAdapter.java
@@ -41,11 +41,8 @@ public class CourseCardButtonAdapter extends CourseCardBaseAdapter
     @Override
     public void onBindViewHolder(@NonNull CourseCardBaseAdapter.ViewHolder holder, int position)
     {
-        String tempURLStr = courses.get(position).courseURL.toString();
-        int idStart = tempURLStr.indexOf("id=");
-
         holder.courseName.setText(courses.get(position).courseName);
-        holder.courseId.setText(tempURLStr.substring(idStart));
+        holder.courseId.setText(courses.get(position).courseTitle);
     }
 
     /**
@@ -82,6 +79,7 @@ public class CourseCardButtonAdapter extends CourseCardBaseAdapter
     public void refreshCourseList()
     {
         SharedPreferences sp = rootView.getContext().getSharedPreferences("courses", Context.MODE_PRIVATE);
+        SharedPreferences titles = rootView.getContext().getSharedPreferences("names", Context.MODE_PRIVATE);
         courses.clear();
 
         if(sp != null)
@@ -100,7 +98,7 @@ public class CourseCardButtonAdapter extends CourseCardBaseAdapter
                     {
                         continue;
                     }
-                    courses.add(new Course(entry.getKey(),courseUrlStr));
+                    courses.add(new Course(entry.getKey(), titles.getString(entry.getKey(),"DEFAULT COURSE TITLE"),courseUrlStr));
                 }
             }
             else

--- a/app/src/main/res/layout/course_card.xml
+++ b/app/src/main/res/layout/course_card.xml
@@ -18,25 +18,28 @@
             android:id="@+id/courseTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            android:layout_marginStart="2dp"
             android:layout_marginTop="20dp"
-            android:layout_marginStart="20dp"
             android:textColor="@color/colorText"
+            android:textFontWeight="600"
             android:textSize="17sp"
-            android:textFontWeight="600"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/courseId"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="50dp"
+            android:layout_height="30dp"
+            android:layout_marginStart="16dp"
             android:layout_marginTop="20dp"
+            android:layout_marginEnd="30dp"
+            android:autoSizeMaxTextSize="17sp"
+            android:autoSizeTextType="uniform"
             android:textColor="@color/colorSelfDefinedHint"
             android:textFontWeight="600"
-            android:textSize="17sp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.3"
+            app:layout_constraintHorizontal_bias="0.30"
+            android:paddingTop="2dp"
             app:layout_constraintStart_toEndOf="@id/courseTitle"
             app:layout_constraintTop_toTopOf="parent" />
         <Button

--- a/app/src/main/res/layout/course_settings_card.xml
+++ b/app/src/main/res/layout/course_settings_card.xml
@@ -18,6 +18,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="17sp"
+        android:singleLine="true"
         android:layout_marginStart="20dp"
         android:layout_marginTop="5dp"
         android:layout_marginBottom="5dp"

--- a/app/src/main/res/layout/edit_course.xml
+++ b/app/src/main/res/layout/edit_course.xml
@@ -28,6 +28,25 @@
         android:textColor="@color/colorText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:text="@string/prompt_course_title" />
+
+    <EditText
+        android:layout_marginStart="10dp"
+        android:id="@+id/edit_course_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:inputType="textUri"
+        android:autofillHints="@string/prompt_course_title"
+        android:hint="@string/example_course_title"/>
+
+    <TextView
+        android:layout_marginStart="5dp"
+        android:textSize="17sp"
+        android:layout_marginTop="7dp"
+        android:textColor="@color/colorText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:text="@string/prompt_enter_course_url" />
 
     <EditText

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,27 @@
+<resources>
+    <string name="app_name">Moodle 帮助</string>
+    <string name="action_settings">设置</string>
+    <string name="invalid_button">应用出错。请重试</string>
+    <string name="prompt_uid">输入Portal用户名</string>
+    <string name="prompt_password">输入Portal密码</string>
+    <string name="initial_uid">您的用户名</string>
+    <string name="initial_pin">您的密码</string>
+    <string name="initial_pin_unchanged">Portal密码（未更改）</string>
+    <string name="title_activity_settings">設置</string>
+    <string name="click_to_course">瀏覽課程資源</string>
+    <string name="prompt_enter_course_name">課程編號</string>
+    <string name="prompt_enter_course_url">課程網址</string>
+    <string name="example_course_name">如：HKUH1005</string>
+    <string name="example_course_url">如：https://moodle.hku.hk/php?id=133355</string>
+    <string name="confirm">確認</string>
+    <string name="cancel">取消</string>
+    <string name="no_course">未有儲存任何課程</string>
+    <string name="wrong_url">不能解析網址。請檢查。</string>
+    <string name="delete_course_setting">移除</string>
+    <string name="download_prompt">正在下載資源</string>
+    <string name="no_download_permission">未給予此程式儲存權限，不能下載</string>
+    <string name="file_save_to">文件被下載至：\n</string>
+    <string name="prompt_course_title">課程名稱</string>
+    <string name="example_course_title">例如：微積分</string>
+    <string name="empty_course_title">【默認課程】</string>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,27 +1,27 @@
 <resources>
-    <string name="app_name">Moodle 帮助</string>
+    <string name="app_name">Moodle助手</string>
     <string name="action_settings">设置</string>
     <string name="invalid_button">应用出错。请重试</string>
-    <string name="prompt_uid">输入Portal用户名</string>
-    <string name="prompt_password">输入Portal密码</string>
-    <string name="initial_uid">您的用户名</string>
-    <string name="initial_pin">您的密码</string>
-    <string name="initial_pin_unchanged">Portal密码（未更改）</string>
+    <string name="prompt_uid">Portal用户名</string>
+    <string name="prompt_password">Portal密码</string>
+    <string name="initial_uid">UID</string>
+    <string name="initial_pin">PIN</string>
+    <string name="initial_pin_unchanged">密码（未更改）</string>
     <string name="title_activity_settings">設置</string>
-    <string name="click_to_course">瀏覽課程資源</string>
-    <string name="prompt_enter_course_name">課程編號</string>
-    <string name="prompt_enter_course_url">課程網址</string>
-    <string name="example_course_name">如：HKUH1005</string>
-    <string name="example_course_url">如：https://moodle.hku.hk/php?id=133355</string>
-    <string name="confirm">確認</string>
+    <string name="click_to_course">浏览课程资源</string>
+    <string name="prompt_enter_course_name">课号</string>
+    <string name="prompt_enter_course_url">网址</string>
+    <string name="example_course_name">例如：HKUH1005</string>
+    <string name="example_course_url">例如：https://moodle.hku.hk/php?id=133355</string>
+    <string name="confirm">确认</string>
     <string name="cancel">取消</string>
-    <string name="no_course">未有儲存任何課程</string>
-    <string name="wrong_url">不能解析網址。請檢查。</string>
-    <string name="delete_course_setting">移除</string>
-    <string name="download_prompt">正在下載資源</string>
-    <string name="no_download_permission">未給予此程式儲存權限，不能下載</string>
-    <string name="file_save_to">文件被下載至：\n</string>
-    <string name="prompt_course_title">課程名稱</string>
-    <string name="example_course_title">例如：微積分</string>
-    <string name="empty_course_title">【默認課程】</string>
+    <string name="no_course">未设置任何课程</string>
+    <string name="wrong_url">不能解析网址。请检查。</string>
+    <string name="delete_course_setting">删除</string>
+    <string name="download_prompt">正在下载资料</string>
+    <string name="no_download_permission">未给予储存权限。下载失败</string>
+    <string name="file_save_to">文件被保存到：\n</string>
+    <string name="prompt_course_title">课名</string>
+    <string name="example_course_title">例如：大学英语</string>
+    <string name="empty_course_title">【默认课程】</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,0 +1,27 @@
+<resources>
+    <string name="app_name">Moodle 幫助</string>
+    <string name="action_settings">設置</string>
+    <string name="invalid_button">程式出錯。請重試</string>
+    <string name="prompt_uid">輸入Portal用戶名</string>
+    <string name="prompt_password">輸入Portal密碼</string>
+    <string name="initial_uid">您的用戶名</string>
+    <string name="initial_pin">您的密碼</string>
+    <string name="initial_pin_unchanged">Portal密碼（未更改）</string>
+    <string name="title_activity_settings">設置</string>
+    <string name="click_to_course">浏览课程资源</string>
+    <string name="prompt_enter_course_name">课号</string>
+    <string name="prompt_enter_course_url">网址</string>
+    <string name="example_course_name">例如：HKUH1005</string>
+    <string name="example_course_url">例如：https://moodle.hku.hk/php?id=133355</string>
+    <string name="confirm">确认</string>
+    <string name="cancel">取消</string>
+    <string name="no_course">未设置任何课程</string>
+    <string name="wrong_url">不能解析网址。请检查。</string>
+    <string name="delete_course_setting">删除</string>
+    <string name="download_prompt">正在下载资料</string>
+    <string name="no_download_permission">未给予储存权限。下载失败</string>
+    <string name="file_save_to">文件被保存到：\n</string>
+    <string name="prompt_course_title">课名</string>
+    <string name="example_course_title">例如：大学英语</string>
+    <string name="empty_course_title">【默认课程】</string>
+</resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,27 +1,27 @@
 <resources>
-    <string name="app_name">Moodle 幫助</string>
+    <string name="app_name">Moodle助手</string>
     <string name="action_settings">設置</string>
     <string name="invalid_button">程式出錯。請重試</string>
-    <string name="prompt_uid">輸入Portal用戶名</string>
-    <string name="prompt_password">輸入Portal密碼</string>
-    <string name="initial_uid">您的用戶名</string>
-    <string name="initial_pin">您的密碼</string>
-    <string name="initial_pin_unchanged">Portal密碼（未更改）</string>
+    <string name="prompt_uid">Portal用戶名</string>
+    <string name="prompt_password">Portal密碼</string>
+    <string name="initial_uid">UID</string>
+    <string name="initial_pin">PIN</string>
+    <string name="initial_pin_unchanged">密碼（未更改）</string>
     <string name="title_activity_settings">設置</string>
-    <string name="click_to_course">浏览课程资源</string>
-    <string name="prompt_enter_course_name">课号</string>
-    <string name="prompt_enter_course_url">网址</string>
-    <string name="example_course_name">例如：HKUH1005</string>
-    <string name="example_course_url">例如：https://moodle.hku.hk/php?id=133355</string>
-    <string name="confirm">确认</string>
+    <string name="click_to_course">瀏覽課程資源</string>
+    <string name="prompt_enter_course_name">課程編號</string>
+    <string name="prompt_enter_course_url">課程網址</string>
+    <string name="example_course_name">如：HKUH1005</string>
+    <string name="example_course_url">如：https://moodle.hku.hk/php?id=133355</string>
+    <string name="confirm">確認</string>
     <string name="cancel">取消</string>
-    <string name="no_course">未设置任何课程</string>
-    <string name="wrong_url">不能解析网址。请检查。</string>
-    <string name="delete_course_setting">删除</string>
-    <string name="download_prompt">正在下载资料</string>
-    <string name="no_download_permission">未给予储存权限。下载失败</string>
-    <string name="file_save_to">文件被保存到：\n</string>
-    <string name="prompt_course_title">课名</string>
-    <string name="example_course_title">例如：大学英语</string>
-    <string name="empty_course_title">【默认课程】</string>
+    <string name="no_course">未有儲存任何課程</string>
+    <string name="wrong_url">不能解析網址。請檢查。</string>
+    <string name="delete_course_setting">移除</string>
+    <string name="download_prompt">正在下載資源</string>
+    <string name="no_download_permission">未給予此程式儲存權限，不能下載</string>
+    <string name="file_save_to">文件被下載至：\n</string>
+    <string name="prompt_course_title">課程名稱</string>
+    <string name="example_course_title">例如：微積分</string>
+    <string name="empty_course_title">【默認課程】</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,6 @@
     <string name="no_download_permission">Cannot download due to no download permission</string>
     <string name="file_save_to">File has been saved to: \n</string>
     <string name="prompt_course_title">Course Title:</string>
-    <string name="example_course_title">Introduction to Campus Life</string>
+    <string name="example_course_title">e.g. Introduction to Campus Life</string>
     <string name="empty_course_title">DEFAULT COURSE TITLE</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="file_save_to">File has been saved to: \n</string>
     <string name="prompt_course_title">Course Title:</string>
     <string name="example_course_title">Introduction to Campus Life</string>
+    <string name="empty_course_title">DEFAULT COURSE TITLE</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="prompt_password">Portal PIN: </string>
     <string name="initial_uid">HKU Portal Login name</string>
     <string name="initial_pin">HKU Portal Login Password</string>
+    <string name="initial_pin_unchanged">Portal PIN (Unchanged)</string>
     <string name="title_activity_settings">SettingsActivity</string>
     <string name="click_to_course">Click to Enter the Course</string>
     <string name="prompt_enter_course_name">Course Name: </string>
@@ -20,4 +21,6 @@
     <string name="download_prompt">Downloading file from Moodle</string>
     <string name="no_download_permission">Cannot download due to no download permission</string>
     <string name="file_save_to">File has been saved to: \n</string>
+    <string name="prompt_course_title">Course Title:</string>
+    <string name="example_course_title">Introduction to Campus Life</string>
 </resources>


### PR DESCRIPTION
### Two features are completed. 
1. Enable the user to enter, store, edit and read the course titles (in addition to the course \#)
1. Enable Simplified Chinese and Traditional Chinese (HK) as displaying languages. The displaying language is always the same as the system default language. 